### PR TITLE
feat: extended app bar and some more tweaks

### DIFF
--- a/components/DefaultAppBar.vue
+++ b/components/DefaultAppBar.vue
@@ -1,0 +1,124 @@
+<template>
+  <v-app-bar
+    app
+    clipped-left
+    clipped-right
+    color="indigo"
+    extension-height="64"
+    fixed
+    hide-on-scroll
+  >
+    <v-app-bar-nav-icon @click="toggleMainDrawer" />
+
+    <v-toolbar-title class="hidden-sm-and-down new-headline">Remembering Louise</v-toolbar-title>
+    <v-toolbar-title class="hidden-md-and-up md-headline">Remembering Louise</v-toolbar-title>
+
+    <v-spacer />
+
+    <v-btn
+      class="v-btn__disabled-active-state"
+      color="purple lighten-4"
+      nuxt
+      rounded
+      style="color: #303f9f"
+      to="/photo-browse"
+    >
+      <v-icon large>mdi-image-search</v-icon>
+      <span class="hidden-sm-and-down">View Photos</span>
+    </v-btn>
+
+    <v-spacer />
+
+    <v-card-actions>
+      <div class="hidden-md-and-down">
+        <v-btn nuxt rounded text to="/service">Funeral Service</v-btn>
+        <v-btn nuxt rounded text to="/remembrances">Remembrances</v-btn>
+      </div>
+
+      <v-menu v-if="user && $auth.user" offset-y>
+        <template v-slot:activator="{ on }">
+          <v-btn fab text v-on="on">
+            <v-avatar :size="35">
+              <v-img alt="$auth.user.name" :src="$auth.user.picture" />
+            </v-avatar>
+          </v-btn>
+        </template>
+        <v-list>
+          <v-list-item @click="logout">
+            <v-icon class="pr-3" large>mdi-account-circle-outline</v-icon>
+            <v-list-item-title>Log Out</v-list-item-title>
+          </v-list-item>
+        </v-list>
+      </v-menu>
+      <v-btn
+        v-else
+        color="green lighten-4"
+        rounded
+        text
+        @click="login"
+      >
+        <v-icon class="mx-1" large>mdi-account-circle-outline</v-icon>
+        <span class="hidden-sm-and-down">Log in</span>
+      </v-btn>
+    </v-card-actions>
+
+    <template v-if="$slots.extension" #extension>
+      <slot name="extension" />
+    </template>
+  </v-app-bar>
+</template>
+
+<script>
+import { mapState } from 'vuex';
+
+export default {
+  name: 'DefaultAppBar',
+
+  computed: {
+    ...mapState({
+      user: state => state.user.user,
+    }),
+  },
+
+  methods: {
+    logout () {
+      this.$auth.logout();
+      this.$store.commit('user/SET_USER', null);
+    },
+    login () {
+      window.localStorage.setItem('redirect_url', this.$route.fullPath);
+      window.localStorage.setItem('resources', JSON.stringify(this.resources_wrap));
+      window.localStorage.setItem('state', JSON.stringify({
+        search_tag: this.search_tag,
+        search_type: this.search_type,
+        detailsPage_url: this.detailsPage_url,
+      }));
+      this.$auth.loginWith('auth0');
+    },
+    toggleMainDrawer () {
+      this.$store.commit('set_main_nav', !this.$store.state.main_nav);
+    },
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+.new-headline {
+  font-family: 'Pinyon Script', cursive;
+  font-size:48px;
+}
+.md-headline  {
+  font-family: 'Pinyon Script', cursive;
+  font-size:30px;
+}
+/* https://github.com/vuetifyjs/vuetify/issues/11149 */
+.v-btn__disabled-active-state::before {
+  opacity: 0 !important;
+}
+</style>
+
+<style>
+.v-app-bar .v-toolbar__extension {
+  background: #263238; /* blue-grey darken-4 */
+}
+</style>

--- a/components/DefaultAppBar.vue
+++ b/components/DefaultAppBar.vue
@@ -70,6 +70,7 @@
 
 <script>
 import { mapState } from 'vuex';
+import { setLocalStorageValue } from '~/util/localStorage';
 
 export default {
   name: 'DefaultAppBar',
@@ -86,13 +87,13 @@ export default {
       this.$store.commit('user/SET_USER', null);
     },
     login () {
-      window.localStorage.setItem('redirect_url', this.$route.fullPath);
-      window.localStorage.setItem('resources', JSON.stringify(this.resources_wrap));
-      window.localStorage.setItem('state', JSON.stringify({
+      setLocalStorageValue('redirect_url', this.$route.fullPath);
+      setLocalStorageValue('resources', this.resources_wrap);
+      setLocalStorageValue('state', {
         search_tag: this.search_tag,
         search_type: this.search_type,
         detailsPage_url: this.detailsPage_url,
-      }));
+      });
       this.$auth.loginWith('auth0');
     },
     toggleMainDrawer () {

--- a/components/DefaultAppBar.vue
+++ b/components/DefaultAppBar.vue
@@ -117,6 +117,7 @@ export default {
 </style>
 
 <style>
+/* https://github.com/vuetifyjs/vuetify/issues/7856 */
 .v-app-bar .v-toolbar__extension {
   background: #263238; /* blue-grey darken-4 */
 }

--- a/components/DefaultAppBar.vue
+++ b/components/DefaultAppBar.vue
@@ -37,7 +37,7 @@
     <template v-if="user && $auth.user">
       <v-btn id="user-button" fab text>
         <v-avatar :size="35">
-          <img alt="$auth.user.name" :src="$auth.user.picture">
+          <img :alt="$auth.user.name" :src="$auth.user.picture">
         </v-avatar>
       </v-btn>
       <v-menu activator="#user-button" offset-y>

--- a/components/DefaultAppBar.vue
+++ b/components/DefaultAppBar.vue
@@ -29,20 +29,18 @@
 
     <v-spacer />
 
-    <v-card-actions>
-      <div class="hidden-md-and-down">
-        <v-btn nuxt rounded text to="/service">Funeral Service</v-btn>
-        <v-btn nuxt rounded text to="/remembrances">Remembrances</v-btn>
-      </div>
+    <div class="hidden-md-and-down">
+      <v-btn nuxt rounded text to="/service">Funeral Service</v-btn>
+      <v-btn nuxt rounded text to="/remembrances">Remembrances</v-btn>
+    </div>
 
-      <v-menu v-if="user && $auth.user" offset-y>
-        <template v-slot:activator="{ on }">
-          <v-btn fab text v-on="on">
-            <v-avatar :size="35">
-              <v-img alt="$auth.user.name" :src="$auth.user.picture" />
-            </v-avatar>
-          </v-btn>
-        </template>
+    <template v-if="user && $auth.user">
+      <v-btn id="user-button" fab text>
+        <v-avatar :size="35">
+          <img alt="$auth.user.name" :src="$auth.user.picture">
+        </v-avatar>
+      </v-btn>
+      <v-menu activator="#user-button" offset-y>
         <v-list>
           <v-list-item @click="logout">
             <v-icon class="pr-3" large>mdi-account-circle-outline</v-icon>
@@ -50,17 +48,17 @@
           </v-list-item>
         </v-list>
       </v-menu>
-      <v-btn
-        v-else
-        color="green lighten-4"
-        rounded
-        text
-        @click="login"
-      >
-        <v-icon class="mx-1" large>mdi-account-circle-outline</v-icon>
-        <span class="hidden-sm-and-down">Log in</span>
-      </v-btn>
-    </v-card-actions>
+    </template>
+    <v-btn
+      v-else
+      color="green lighten-4"
+      rounded
+      text
+      @click="login"
+    >
+      <v-icon class="mx-1" large>mdi-account-circle-outline</v-icon>
+      <span class="hidden-sm-and-down">Log in</span>
+    </v-btn>
 
     <template v-if="$slots.extension" #extension>
       <slot name="extension" />

--- a/components/SearchDrawer.vue
+++ b/components/SearchDrawer.vue
@@ -82,13 +82,14 @@ export default {
     search () {
       return this.$route.query.search || '';
     },
+    queryJson () {
+      return JSON.stringify(this.$route.query);
+    },
   },
 
   watch: {
-    '$route.query': {
-      immediate: true,
-      deep: true,
-      async handler (query) {
+    queryJson: {
+      async handler () {
         const searchTags = this.search.split('-');
 
         if (this.search) {

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -27,19 +27,19 @@
         </v-list-item> -->
       </v-list>
     </v-navigation-drawer>
+    <v-navigation-drawer
+      v-if="hasSearchDrawer"
+      app
+      clipped
+      fixed
+      :mobile-break-point="0"
+      right
+      :width="tagNavWidth"
+    >
+      <search-drawer />
+    </v-navigation-drawer>
     <v-content>
       <nuxt />
-      <v-navigation-drawer
-        v-if="hasSearchDrawer"
-        app
-        clipped
-        fixed
-        :mobile-break-point="0"
-        right
-        :width="tagNavWidth"
-      >
-        <search-drawer />
-      </v-navigation-drawer>
     </v-content>
     <v-footer
       dark

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -87,6 +87,7 @@
 import { mapState } from 'vuex';
 import SearchDrawer from '@/components/SearchDrawer';
 import { createShareIcons } from '~/util/share.js';
+import { getLocalStorageValue } from '~/util/localStorage';
 
 export default {
   components: {
@@ -149,7 +150,7 @@ export default {
   },
   async mounted () {
     if (this.$auth && this.$auth.user && !this.user) {
-      await this.$store.commit('user/SET_USER', JSON.parse(window.localStorage.getItem('rememberinglouise_user')));
+      await this.$store.commit('user/SET_USER', getLocalStorageValue('rememberinglouise_user'));
     }
     await this.$store.dispatch('tags/gettags');
   },

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -5,7 +5,7 @@
       app
       clipped
       fixed
-      :mini-variant="miniVariant"
+      :mini-variant.sync="miniVariant"
     >
       <v-list>
         <v-list-item
@@ -27,64 +27,6 @@
         </v-list-item> -->
       </v-list>
     </v-navigation-drawer>
-    <v-app-bar
-      app
-      clipped-left
-      clipped-right
-      color="indigo"
-      fixed
-      :hide-on-scroll="true"
-    >
-      <v-app-bar-nav-icon @click.stop="drawer = !drawer" />
-      <div class="hidden-sm-and-down">
-        <v-toolbar-title class="new-headline" v-text="title" />
-      </div>
-      <div class="hidden-md-and-up">
-        <v-toolbar-title class="md-headline" v-text="title" />
-      </div>
-      <v-spacer />
-      <div>
-        <v-btn
-          color="purple lighten-4"
-          rounded
-        >
-          <nuxt-link to="/photo-browse">
-            <v-icon large>mdi-image-search</v-icon>
-            <span class="hidden-sm-and-down">View Photos</span>
-          </nuxt-link>
-        </v-btn>
-      </div>
-      <v-spacer />
-      <v-card-actions>
-        <div class="hidden-md-and-down">
-          <nuxt-link to="/service">
-            <v-btn text>Funeral Service</v-btn></nuxt-link>
-          <nuxt-link to="/remembrances">
-            <v-btn text>Remembrances</v-btn></nuxt-link>
-        </div>
-        <v-menu v-if="user && $auth.user" offset-y>
-          <template v-slot:activator="{ on }">
-            <v-btn fab text v-on="on">
-              <v-avatar :size="35">
-                <v-img alt="$auth.user.name" :src="$auth.user.picture" />
-              </v-avatar>
-            </v-btn>
-          </template>
-          <v-list>
-            <v-list-item @click="onLogout">
-              <v-icon class="pr-3" large>mdi-account-circle-outline</v-icon>
-              <v-list-item-title>Log Out</v-list-item-title>
-            </v-list-item>
-          </v-list>
-        </v-menu>
-        <v-btn v-else color="green lighten-4"
-               rounded text @click="login"
-        >
-          <v-icon large>mdi-account-circle-outline</v-icon>
-          <span class="hidden-sm-and-down">Log in</span>
-        </v-btn>
-      </v-card-actions>
-    </v-app-bar>
     <v-content>
       <nuxt />
       <v-navigation-drawer
@@ -153,7 +95,6 @@ export default {
 
   data () {
     return {
-      drawer: false,
       items: [
         {
           icon: 'mdi-apps',
@@ -178,7 +119,6 @@ export default {
       ],
       shareIcons: createShareIcons(process.env.BASE_URL.replace(/\/$/, '') + this.$nuxt.$route.fullPath),
       miniVariant: false,
-      title: 'Remembering Louise',
     };
   },
 
@@ -198,28 +138,20 @@ export default {
     tagNavWidth: function () {
       return this.$vuetify.breakpoint.smAndDown ? 300 : 360;
     },
+    drawer: {
+      get () {
+        return this.$store.state.main_nav;
+      },
+      set (value) {
+        this.$store.commit('set_main_nav', value);
+      },
+    },
   },
   async mounted () {
     if (this.$auth && this.$auth.user && !this.user) {
       await this.$store.commit('user/SET_USER', JSON.parse(window.localStorage.getItem('rememberinglouise_user')));
     }
     await this.$store.dispatch('tags/gettags');
-  },
-  methods: {
-    onLogout () {
-      this.$auth.logout();
-      this.$store.commit('user/SET_USER', null);
-    },
-    login () {
-      window.localStorage.setItem('redirect_url', this.$route.fullPath);
-      window.localStorage.setItem('resources', JSON.stringify(this.resources_wrap));
-      window.localStorage.setItem('state', JSON.stringify({
-        search_tag: this.search_tag,
-        search_type: this.search_type,
-        detailsPage_url: this.detailsPage_url,
-      }));
-      this.$auth.loginWith('auth0');
-    },
   },
   head () {
     return {
@@ -230,17 +162,3 @@ export default {
   },
 };
 </script>
-
-<style lang="scss" scoped>
-.new-headline {
-  font-family: 'Pinyon Script', cursive;
-  font-size:48px;
-}
-.md-headline  {
-  font-family: 'Pinyon Script', cursive;
-  font-size:30px;
-}
-a {
-  text-decoration: none;
-}
-</style>

--- a/pages/auth-discourse.vue
+++ b/pages/auth-discourse.vue
@@ -1,23 +1,28 @@
 <template>
-  <v-container>
-    <v-container fluid>
-      <v-row align="center" class="loading-row" justify="center">
-        <v-progress-circular color="gray" indeterminate :size="200" :width="20" />
-      </v-row>
-    </v-container>
+  <v-container fluid>
+    <default-app-bar />
+    <v-row align="center" class="loading-row" justify="center">
+      <v-progress-circular color="gray" indeterminate :size="200" :width="20" />
+    </v-row>
   </v-container>
 </template>
 
 <script>
 import { mapState } from 'vuex';
 import { getLocalStorageValue } from '~/util/localStorage';
+import DefaultAppBar from '~/components/DefaultAppBar';
 
 export default {
+  components: {
+    DefaultAppBar,
+  },
+
   computed: {
     ...mapState({
       user: state => state.user.user,
     }),
   },
+
   async mounted () {
     console.log(this.$auth.user);
     await this.$store.dispatch('user/set_user', { user: this.$auth.user });

--- a/pages/auth-discourse.vue
+++ b/pages/auth-discourse.vue
@@ -10,6 +10,7 @@
 
 <script>
 import { mapState } from 'vuex';
+import { getLocalStorageValue } from '~/util/localStorage';
 
 export default {
   computed: {
@@ -24,7 +25,7 @@ export default {
     console.log(this.user);
     if (process.browser) {
       this.$router.replace({
-        path: window.localStorage.getItem('redirect_url'),
+        path: getLocalStorageValue('redirect_url'),
       });
     }
   },

--- a/pages/auth-redirect.vue
+++ b/pages/auth-redirect.vue
@@ -1,12 +1,21 @@
 <template>
-  <v-container>
-    <v-container fluid>
-      <v-row align="center" class="loading-row" justify="center">
-        <v-progress-circular color="gray" indeterminate :size="200" :width="20" />
-      </v-row>
-    </v-container>
+  <v-container fluid>
+    <default-app-bar />
+    <v-row align="center" class="loading-row" justify="center">
+      <v-progress-circular color="gray" indeterminate :size="200" :width="20" />
+    </v-row>
   </v-container>
 </template>
+
+<script>
+import DefaultAppBar from '~/components/DefaultAppBar';
+
+export default {
+  components: {
+    DefaultAppBar,
+  },
+};
+</script>
 
 <style lang="scss" scoped>
 .loading-row {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,74 +1,82 @@
 <template>
-  <v-container>
-    <v-card
-      class="mx-auto" max-width="1500"
-    >
-      <v-container fluid>
-        <v-row>
-          <v-col
-            cols="12"
-            lg="4"
-            md="4"
-          >
-            <v-card>
-              <v-card-subtitle class="headline font-italic">
-                Dedicated to Louise Carter, amazing mom, wife, friend, and photo archivist
-              </v-card-subtitle>
-              <v-btn color="green" href="https://us02web.zoom.us/j/85836340855" x-large>Join Funeral Service</v-btn>
-              <v-card-text class="title">
-                Please click the button above to join the virtual funeral we're holding for Louise today at 1 PM EDT.
-              </v-card-text>
-            </v-card>
-          </v-col>
-          <v-col>
-            <v-card align="center">
-              <v-carousel
-                cycle
-                height="550"
-                hide-delimiters
-              >
-                <v-carousel-item
-                  v-for="(image, i) in images"
-                  :key="i"
+  <div>
+    <default-app-bar />
+    <v-container>
+      <v-card
+        class="mx-auto" max-width="1500"
+      >
+        <v-container fluid>
+          <v-row>
+            <v-col
+              cols="12"
+              lg="4"
+              md="4"
+            >
+              <v-card>
+                <v-card-subtitle class="headline font-italic">
+                  Dedicated to Louise Carter, amazing mom, wife, friend, and photo archivist
+                </v-card-subtitle>
+                <v-btn color="green" href="https://us02web.zoom.us/j/85836340855" x-large>Join Funeral Service</v-btn>
+                <v-card-text class="title">
+                  Please click the button above to join the virtual funeral we're holding for Louise today at 1 PM EDT.
+                </v-card-text>
+              </v-card>
+            </v-col>
+            <v-col>
+              <v-card align="center">
+                <v-carousel
+                  cycle
+                  height="550"
+                  hide-delimiters
                 >
-                  <v-sheet
-                    color="black"
-                    height="100%"
+                  <v-carousel-item
+                    v-for="(image, i) in images"
+                    :key="i"
                   >
-                    <v-row
-                      align="center"
-                      class="fill-height"
-                      justify="center"
+                    <v-sheet
+                      color="black"
+                      height="100%"
                     >
-                      <v-col
+                      <v-row
                         align="center"
-                        md="12"
+                        class="fill-height"
+                        justify="center"
                       >
-                        <cld-image :public-id="images[i]" secure="true">
-                          <cld-transformation crop="fill" gravity="faces" height="550" width="550" />
-                        </cld-image>
-                      </v-col>
-                    </v-row>
-                  </v-sheet>
-                </v-carousel-item>
-              </v-carousel>
-            </v-card>
-          </v-col>
-        </v-row>
-      </v-container>
-    </v-card>
-  </v-container>
+                        <v-col
+                          align="center"
+                          md="12"
+                        >
+                          <cld-image :public-id="images[i]" secure="true">
+                            <cld-transformation crop="fill" gravity="faces" height="550" width="550" />
+                          </cld-image>
+                        </v-col>
+                      </v-row>
+                    </v-sheet>
+                  </v-carousel-item>
+                </v-carousel>
+              </v-card>
+            </v-col>
+          </v-row>
+        </v-container>
+      </v-card>
+    </v-container>
+  </div>
 </template>
 
 <script>
 import Vue from 'vue';
 import Cloudinary from 'cloudinary-vue';
+import DefaultAppBar from '~/components/DefaultAppBar';
 
 Vue.use(Cloudinary, {
   configuration: { cloudName: 'louise' },
 });
 
 export default {
+  components: {
+    DefaultAppBar,
+  },
+
   data () {
     return {
       images: [

--- a/pages/photo-browse.vue
+++ b/pages/photo-browse.vue
@@ -222,8 +222,7 @@ export default {
       });
     },
     onTagNav () {
-      this.$store.commit('set_tag_nav', true);
-      console.log(this.tag_nav);
+      this.$store.commit('set_tag_nav', !this.tag_nav);
     },
     setloading (flag) {
       this.$store.commit('set_browse_loading', flag);

--- a/pages/photo-browse.vue
+++ b/pages/photo-browse.vue
@@ -1,8 +1,6 @@
 <template>
   <div>
-    <v-app-bar
-      color="blue-grey darken-4"
-    >
+    <default-app-bar #extension>
       <v-spacer />
 
       <v-tooltip bottom>
@@ -44,7 +42,7 @@
       <v-spacer />
 
       <toolbar-share-button />
-    </v-app-bar>
+    </default-app-bar>
     <v-container>
       <v-card id="browse-card" class="mx-auto">
         <v-container fluid>
@@ -81,16 +79,18 @@ import Vue from 'vue';
 import { mapState } from 'vuex';
 import Cloudinary from 'cloudinary-vue';
 import ToolbarShareButton from '~/components/ToolbarShareButton';
+import DefaultAppBar from '~/components/DefaultAppBar';
 
 Vue.use(Cloudinary, {
   configuration: { cloudName: 'louise' },
 });
 
 export default {
-
   components: {
+    DefaultAppBar,
     ToolbarShareButton,
   },
+
   async asyncData ({ $axios, store, error }) {},
 
   data () {
@@ -100,6 +100,7 @@ export default {
       uploading: false, // false - no upload, true - dialog opened, null - dialog opening
     };
   },
+
   computed: {
     ...mapState({
       user: state => state.user.user,

--- a/pages/photo/_id.vue
+++ b/pages/photo/_id.vue
@@ -219,7 +219,7 @@ export default {
       this.$store.commit('set_just_login', false);
 
       this.$store.commit('set_details_state', getLocalStorageValue('state'));
-      this.$store.commit('resources/parse', getLocalStorageValue('resources'));
+      this.$store.commit('resources/parse', getLocalStorageValue('resources') || {});
     }
 
     this.$store.commit('comments/init');

--- a/pages/photo/_id.vue
+++ b/pages/photo/_id.vue
@@ -1,8 +1,6 @@
 <template>
   <div>
-    <v-app-bar
-      color="blue-grey darken-4"
-    >
+    <default-app-bar #extension>
       <v-btn
         color="orange lighten-1"
         rounded
@@ -109,7 +107,7 @@
       <v-spacer />
 
       <toolbar-share-button />
-    </v-app-bar>
+    </default-app-bar>
     <v-container class="mb-2" fluid max-width="1200">
       <v-card
         class="mx-auto"
@@ -149,6 +147,7 @@ import axios from 'axios';
 // import Comments from '~/components/Comments';
 import CommentUpload from '~/components/CommentUpload';
 import ToolbarShareButton from '~/components/ToolbarShareButton';
+import DefaultAppBar from '~/components/DefaultAppBar';
 
 Vue.use(Cloudinary, {
   configuration: { cloudName: 'louise' },
@@ -158,6 +157,7 @@ export default {
   components: {
     // Comments,
     CommentUpload,
+    DefaultAppBar,
     ToolbarShareButton,
   },
   data () {

--- a/pages/photo/_id.vue
+++ b/pages/photo/_id.vue
@@ -148,6 +148,7 @@ import axios from 'axios';
 import CommentUpload from '~/components/CommentUpload';
 import ToolbarShareButton from '~/components/ToolbarShareButton';
 import DefaultAppBar from '~/components/DefaultAppBar';
+import { getLocalStorageValue, setLocalStorageValue } from '~/util/localStorage';
 
 Vue.use(Cloudinary, {
   configuration: { cloudName: 'louise' },
@@ -216,12 +217,9 @@ export default {
     }
     if (this.just_login) {
       this.$store.commit('set_just_login', false);
-      const local_state = JSON.parse(window.localStorage.getItem('state'));
 
-      const local_resources = JSON.parse(window.localStorage.getItem('resources'));
-
-      this.$store.commit('set_details_state', local_state);
-      this.$store.commit('resources/parse', local_resources);
+      this.$store.commit('set_details_state', getLocalStorageValue('state'));
+      this.$store.commit('resources/parse', getLocalStorageValue('resources'));
     }
 
     this.$store.commit('comments/init');
@@ -235,13 +233,13 @@ export default {
   },
   methods: {
     login () {
-      window.localStorage.setItem('redirect_url', this.$route.fullPath);
-      window.localStorage.setItem('resources', JSON.stringify(this.resources_wrap));
-      window.localStorage.setItem('state', JSON.stringify({
+      setLocalStorageValue('redirect_url', this.$route.fullPath);
+      setLocalStorageValue('resources', this.resources_wrap);
+      setLocalStorageValue('state', {
         search_tag: this.search_tag,
         search_type: this.search_type,
         detailsPage_url: this.detailsPage_url,
-      }));
+      });
       this.$auth.loginWith('auth0');
     },
     onCommentIcon () {

--- a/pages/remembrances.vue
+++ b/pages/remembrances.vue
@@ -1,37 +1,42 @@
 <template>
-  <v-container>
-    <v-container class="mb-2" fluid max-width="1200">
-      <v-card
-        class="mx-auto"
-        max-width="1200"
-      >
-        <div class="hidden-lg-and-up">
-          <v-card-title class="new-headline">Share a Remembrance</v-card-title>
-        </div>
-        <div class="hidden-md-and-down">
-          <v-card-title class="new-headline">Share a Remembrance</v-card-title>
-        </div>      <v-card-text class="headline">Whether it was the time you spent together, what she meant to you, your favorite or funniest moment, whatever you would want the world to know about you and Louise.</v-card-text>
-        <comments id="comment_show" title="Remembrances" />
-        <v-row v-if="!user" align="center" dense justify="center">
-          <v-btn class="mb-3" color="orange darken-2" normal @click="login">Add a remembrance</v-btn>
-        </v-row>
-        <div class="pa-2">
-          <comment-upload id="comment_upload" title="Remembrances" />
-        </div>
-      </v-card>
+  <div>
+    <default-app-bar />
+    <v-container>
+      <v-container class="mb-2" fluid max-width="1200">
+        <v-card
+          class="mx-auto"
+          max-width="1200"
+        >
+          <div class="hidden-lg-and-up">
+            <v-card-title class="new-headline">Share a Remembrance</v-card-title>
+          </div>
+          <div class="hidden-md-and-down">
+            <v-card-title class="new-headline">Share a Remembrance</v-card-title>
+          </div>      <v-card-text class="headline">Whether it was the time you spent together, what she meant to you, your favorite or funniest moment, whatever you would want the world to know about you and Louise.</v-card-text>
+          <comments id="comment_show" title="Remembrances" />
+          <v-row v-if="!user" align="center" dense justify="center">
+            <v-btn class="mb-3" color="orange darken-2" normal @click="login">Add a remembrance</v-btn>
+          </v-row>
+          <div class="pa-2">
+            <comment-upload id="comment_upload" title="Remembrances" />
+          </div>
+        </v-card>
+      </v-container>
     </v-container>
-  </v-container>
+  </div>
 </template>
 
 <script>
 import { mapState } from 'vuex';
 import Comments from '~/components/Comments';
 import CommentUpload from '~/components/CommentUpload';
+import DefaultAppBar from '~/components/DefaultAppBar';
 
 export default {
   components: {
     Comments,
     CommentUpload,
+    DefaultAppBar,
   },
   computed: {
     ...mapState({

--- a/pages/remembrances.vue
+++ b/pages/remembrances.vue
@@ -31,6 +31,7 @@ import { mapState } from 'vuex';
 import Comments from '~/components/Comments';
 import CommentUpload from '~/components/CommentUpload';
 import DefaultAppBar from '~/components/DefaultAppBar';
+import { setLocalStorageValue } from '~/util/localStorage';
 
 export default {
   components: {
@@ -49,13 +50,13 @@ export default {
   },
   methods: {
     login () {
-      window.localStorage.setItem('redirect_url', this.$route.fullPath);
-      window.localStorage.setItem('resources', JSON.stringify(this.resources_wrap));
-      window.localStorage.setItem('state', JSON.stringify({
+      setLocalStorageValue('redirect_url', this.$route.fullPath);
+      setLocalStorageValue('resources', this.resources_wrap);
+      setLocalStorageValue('state', {
         search_tag: this.search_tag,
         search_type: this.search_type,
         detailsPage_url: this.detailsPage_url,
-      }));
+      });
       this.$auth.loginWith('auth0');
     },
   },

--- a/pages/service.vue
+++ b/pages/service.vue
@@ -1,46 +1,55 @@
 <template>
-  <v-container>
-    <v-card class="mx-auto" max-width="1500">
-      <v-container fluid>
-        <v-row>
-          <v-col
-            cols="12"
-            lg="4"
-            sm="4"
-          >
-            <v-card>
-              <h2>Funeral Service and Events</h2>
-              <v-card-subtitle class="headline">
-                St. Theresa's Church, West Roxbury, MA<hr>June 3, 2020, 1 PM EDT
-              </v-card-subtitle>
-              <v-card-text class="title">
-                <p>Select the button below to join </p>
-              </v-card-text>
-              <v-card-actions>
-                <v-btn
-                  href="https://us02web.zoom.us/j/85836340855"
-                  text
-                >
-                  <v-icon large>mdi-calendar-star</v-icon>
-                  Funeral <br> June 3, 1 pm et
-                </v-btn>
-              </v-card-actions>
-            </v-card>
-          </v-col>
-          <v-col class="info darken-2">
-            <h3>Joining a Zoom Meeting</h3>
-            <p class="zoom-links">We recommend you <b>install the Zoom app</b> on whatever device you plan to use to access the meeting: <v-btn color="blue darken-1" href="https://zoom.us/client/latest/Zoom.pkg"><v-icon color="white" justify="space-around">mdi-laptop-mac</v-icon> computer</v-btn>, <v-btn color="purple darken-1" href="https://itunes.apple.com/us/app/id546505307"><v-icon color="white" justify="space-around">mdi-cellphone-iphone</v-icon>iPhone or iPad</v-btn>, or <v-btn color="orange darken-1" href="https://play.google.com/store/apps/details?id=us.zoom.videomeetings"><v-icon color="white" justify="space-around">mdi-cellphone-android</v-icon>Android phone</v-btn></p>
-            <p>You can  access the service using just your web browser, but may not be able to share video or your screen in the discussion after the burial service is complete. For best results please use <v-btn color="orange darken-1" href="https://www.google.com/chrome/https://itunes.apple.com/us/app/id546505307"><v-icon color="white" justify="space-around">mdi-google-chrome</v-icon>Chrome</v-btn> or <v-btn color="green lighten-2" href="https://www.mozilla.org/en-US/firefox/new/"><v-icon color="white" justify="space-around">mdi-firefox</v-icon>Firefox</v-btn></p>
-            <p>When you're ready to join the service, click the button at left and you'll be taken to the meeting. Before you join, if you have the app installed, you'll be prompted whether you want to open the meeting in the app. Choose the <v-btn color="orange darken-1">Allow</v-btn> button and you should be good to go. We're looking forward to you joining us!</p>
-          </v-col>
-        </v-row>
-      </v-container>
-    </v-card>
-  </v-container>
+  <div>
+    <default-app-bar />
+    <v-container>
+      <v-card class="mx-auto" max-width="1500">
+        <v-container fluid>
+          <v-row>
+            <v-col
+              cols="12"
+              lg="4"
+              sm="4"
+            >
+              <v-card>
+                <h2>Funeral Service and Events</h2>
+                <v-card-subtitle class="headline">
+                  St. Theresa's Church, West Roxbury, MA<hr>June 3, 2020, 1 PM EDT
+                </v-card-subtitle>
+                <v-card-text class="title">
+                  <p>Select the button below to join </p>
+                </v-card-text>
+                <v-card-actions>
+                  <v-btn
+                    href="https://us02web.zoom.us/j/85836340855"
+                    text
+                  >
+                    <v-icon large>mdi-calendar-star</v-icon>
+                    Funeral <br> June 3, 1 pm et
+                  </v-btn>
+                </v-card-actions>
+              </v-card>
+            </v-col>
+            <v-col class="info darken-2">
+              <h3>Joining a Zoom Meeting</h3>
+              <p class="zoom-links">We recommend you <b>install the Zoom app</b> on whatever device you plan to use to access the meeting: <v-btn color="blue darken-1" href="https://zoom.us/client/latest/Zoom.pkg"><v-icon color="white" justify="space-around">mdi-laptop-mac</v-icon> computer</v-btn>, <v-btn color="purple darken-1" href="https://itunes.apple.com/us/app/id546505307"><v-icon color="white" justify="space-around">mdi-cellphone-iphone</v-icon>iPhone or iPad</v-btn>, or <v-btn color="orange darken-1" href="https://play.google.com/store/apps/details?id=us.zoom.videomeetings"><v-icon color="white" justify="space-around">mdi-cellphone-android</v-icon>Android phone</v-btn></p>
+              <p>You can  access the service using just your web browser, but may not be able to share video or your screen in the discussion after the burial service is complete. For best results please use <v-btn color="orange darken-1" href="https://www.google.com/chrome/https://itunes.apple.com/us/app/id546505307"><v-icon color="white" justify="space-around">mdi-google-chrome</v-icon>Chrome</v-btn> or <v-btn color="green lighten-2" href="https://www.mozilla.org/en-US/firefox/new/"><v-icon color="white" justify="space-around">mdi-firefox</v-icon>Firefox</v-btn></p>
+              <p>When you're ready to join the service, click the button at left and you'll be taken to the meeting. Before you join, if you have the app installed, you'll be prompted whether you want to open the meeting in the app. Choose the <v-btn color="orange darken-1">Allow</v-btn> button and you should be good to go. We're looking forward to you joining us!</p>
+            </v-col>
+          </v-row>
+        </v-container>
+      </v-card>
+    </v-container>
+  </div>
 </template>
 
 <script>
+import DefaultAppBar from '~/components/DefaultAppBar';
+
 export default {
+  components: {
+    DefaultAppBar,
+  },
+
   data () {
     return {
       colors: [

--- a/pages/slideshow.vue
+++ b/pages/slideshow.vue
@@ -1,8 +1,6 @@
 <template>
   <div>
-    <v-app-bar
-      color="blue-grey darken-4"
-    >
+    <default-app-bar #extension>
       <v-btn
         color="orange lighten-1"
         rounded
@@ -11,7 +9,7 @@
         <v-icon left>mdi-arrow-left</v-icon>
         Back
       </v-btn>
-    </v-app-bar>
+    </default-app-bar>
     <v-container>
       <slide-show />
     </v-container>
@@ -21,16 +19,20 @@
 <script>
 import SlideShow from '../components/SlideShow';
 import { mapState } from 'vuex';
+import DefaultAppBar from '~/components/DefaultAppBar';
 
 export default {
   components: {
     SlideShow,
+    DefaultAppBar,
   },
+
   computed: {
     ...mapState({
       detailsPage_url: state => state.detailsPage_url,
     }),
   },
+
   methods: {
     onBack () {
       this.$router.replace({ path: this.detailsPage_url });

--- a/store/index.js
+++ b/store/index.js
@@ -2,6 +2,7 @@
 export const state = () => ({
   detailsPage_url: null,
   tag_nav: false,
+  main_nav: null,
   browse_loading: true,
   search_tag: null,
   search_type: null,
@@ -21,5 +22,8 @@ export const mutations = {
   },
   set_just_login (state, flag) {
     state.just_login = flag;
+  },
+  set_main_nav (state, value) {
+    state.main_nav = value;
   },
 };

--- a/store/user.js
+++ b/store/user.js
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { setLocalStorageValue } from '~/util/localStorage';
 
 export const state = () => ({
   user: null,
@@ -17,7 +18,7 @@ export const mutations = {
         }
       });
     }
-    window.localStorage.setItem('rememberinglouise_user', data);
+    setLocalStorageValue('rememberinglouise_user', data);
   },
 };
 

--- a/util/localStorage.js
+++ b/util/localStorage.js
@@ -1,0 +1,16 @@
+export function setLocalStorageValue (key, value) {
+  window.localStorage.setItem(key, value === 'undefined' ? 'undefined' : JSON.stringify(value));
+}
+
+export function getLocalStorageValue (key) {
+  const value = localStorage.getItem(key);
+
+  if (value === undefined || value === 'undefined') return undefined;
+
+  try {
+    return JSON.parse(value);
+  } catch (e) {
+    console.error(`Invalid JSON value for key ${key}: ${value}`);
+    return undefined;
+  }
+}


### PR DESCRIPTION
fixes #58

1. Refactored app bar. After scrolling the page upper part hides leaving only lower part visible:
![image](https://user-images.githubusercontent.com/15625235/85947605-10e02700-b94c-11ea-8d31-36bafb23bbc0.png)

2. Fixed app bar title. Before:
![image](https://user-images.githubusercontent.com/15625235/85947618-22c1ca00-b94c-11ea-944c-aeaa43b008fb.png)
After:
![image](https://user-images.githubusercontent.com/15625235/85947623-281f1480-b94c-11ea-913e-6ce656f50c46.png)

3. Fixed console error:
![image](https://user-images.githubusercontent.com/15625235/85947640-44bb4c80-b94c-11ea-9d6a-3632a1f6239e.png)

4. Clicking "Browse" button on `/photo-browse` now closes search navigation drawer when it's open

5. Opening search navigation drawer now doesn't trigger reloading of photos